### PR TITLE
New releases monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 dist/
 coverage.out
+.idea

--- a/client/cache.go
+++ b/client/cache.go
@@ -43,3 +43,15 @@ func (c cachedClient) Assets(repo string, id int64) ([]Asset, error) {
 	c.cache.Set(key, live, cache.DefaultExpiration)
 	return live, err
 }
+
+func (c cachedClient) GetLatestRelease(repo string) (*LatestRelease, error) {
+	cached, found := c.cache.Get(repo)
+	if found {
+		log.Debugf("getting releases for %s from cache", repo)
+		return cached.(*LatestRelease), nil
+	}
+	log.Debugf("getting releases for %s from API", repo)
+	live, err := c.client.GetLatestRelease(repo)
+	c.cache.Set(repo, live, cache.DefaultExpiration)
+	return live, err
+}

--- a/client/client.go
+++ b/client/client.go
@@ -3,11 +3,18 @@ package client
 type Client interface {
 	Releases(repo string) ([]Release, error)
 	Assets(repo string, id int64) ([]Asset, error)
+	GetLatestRelease(repo string) (*LatestRelease, error)
 }
 
 type Release struct {
 	ID  int64
 	Tag string
+}
+
+type LatestRelease struct {
+	Tag      string
+	Name     string
+	UnixTime int64
 }
 
 type Asset struct {

--- a/collector/releases.go
+++ b/collector/releases.go
@@ -115,9 +115,9 @@ func (c *releasesCollector) Collect(ch chan<- prometheus.Metric) {
 				c.release,
 				prometheus.CounterValue,
 				float64(release.UnixTime),
-				release.Name,
-				release.Tag,
 				repository,
+				release.Tag,
+				release.Name,
 			)
 		} else {
 			releases, err := c.client.Releases(repository)

--- a/collector/releases.go
+++ b/collector/releases.go
@@ -13,10 +13,10 @@ import (
 )
 
 type releasesCollector struct {
-	mutex  sync.Mutex
-	config *config.Config
-	client client.Client
-
+	mutex          sync.Mutex
+	config         *config.Config
+	client         client.Client
+	release        *prometheus.Desc
 	up             *prometheus.Desc
 	downloads      *prometheus.Desc
 	scrapeDuration *prometheus.Desc
@@ -26,35 +26,72 @@ type releasesCollector struct {
 func NewReleasesCollector(config *config.Config, client client.Client) prometheus.Collector {
 	const namespace = "github"
 	const subsystem = "release"
-	return &releasesCollector{
-		config: config,
-		client: client,
-		up: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "up"),
-			"Exporter is being able to talk with GitHub API",
-			nil,
-			nil,
-		),
-		downloads: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "asset_download_count"),
-			"Download count of each asset of a github release",
-			[]string{"repository", "tag", "name", "extension"},
-			nil,
-		),
-		scrapeDuration: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "scrape_duration_seconds"),
-			"Returns how long the probe took to complete in seconds",
-			nil,
-			nil,
-		),
+	if config.OnlyNewReleaseInfo {
+		return &releasesCollector{
+			config: config,
+			client: client,
+			release: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "latest_info"),
+				"Latest release info of the repo",
+				[]string{"repository", "tag", "name"},
+				nil,
+			),
+			up: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "up"),
+				"Exporter is being able to talk with GitHub API",
+				nil,
+				nil,
+			),
+			scrapeDuration: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "scrape_duration_seconds"),
+				"Returns how long the probe took to complete in seconds",
+				nil,
+				nil,
+			),
+		}
+	} else {
+		return &releasesCollector{
+			config: config,
+			client: client,
+			release: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "latest_info"),
+				"Latest release info of the repo",
+				[]string{"repository", "tag", "name"},
+				nil,
+			),
+			up: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "up"),
+				"Exporter is being able to talk with GitHub API",
+				nil,
+				nil,
+			),
+			downloads: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "asset_download_count"),
+				"Download count of each asset of a github release",
+				[]string{"repository", "tag", "name", "extension"},
+				nil,
+			),
+			scrapeDuration: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "scrape_duration_seconds"),
+				"Returns how long the probe took to complete in seconds",
+				nil,
+				nil,
+			),
+		}
 	}
 }
 
 // Describe all metrics
 func (c *releasesCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.up
-	ch <- c.downloads
-	ch <- c.scrapeDuration
+	if c.config.OnlyNewReleaseInfo {
+		ch <- c.up
+		ch <- c.release
+		ch <- c.scrapeDuration
+	} else {
+		ch <- c.up
+		ch <- c.downloads
+		ch <- c.scrapeDuration
+	}
 }
 
 // Collect all metrics
@@ -67,43 +104,60 @@ func (c *releasesCollector) Collect(ch chan<- prometheus.Metric) {
 	var success = 1
 	for _, repository := range c.config.Repositories {
 		log.Infof("collecting %s", repository)
-		releases, err := c.client.Releases(repository)
-		if err != nil {
-			success = 0
-			log.Errorf("failed to collect: %s", err.Error())
-			continue
-		}
-
-		for _, release := range releases {
-			assets, err := c.client.Assets(repository, release.ID)
+		if c.config.OnlyNewReleaseInfo {
+			release, err := c.client.GetLatestRelease(repository)
 			if err != nil {
 				success = 0
-				log.Errorf(
-					"failed to collect repo %s, release %s: %s",
-					repository,
-					release.Tag,
-					err.Error(),
-				)
+				log.Errorf("failed to collect: %s", err.Error())
 				continue
 			}
-			for _, asset := range assets {
-				ext :=  strings.TrimPrefix(filepath.Ext(asset.Name), ".")
-				log.Debugf(
-					"collecting %s@%s / %s (%s)",
-					repository,
-					release.Tag,
-					asset.Name,
-					ext,
-				)
-				ch <- prometheus.MustNewConstMetric(
-					c.downloads,
-					prometheus.CounterValue,
-					float64(asset.Downloads),
-					repository,
-					release.Tag,
-					asset.Name,
-					ext,
-				)
+			ch <- prometheus.MustNewConstMetric(
+				c.release,
+				prometheus.CounterValue,
+				float64(release.UnixTime),
+				release.Name,
+				release.Tag,
+				repository,
+			)
+		} else {
+			releases, err := c.client.Releases(repository)
+			if err != nil {
+				success = 0
+				log.Errorf("failed to collect: %s", err.Error())
+				continue
+			}
+
+			for _, release := range releases {
+				assets, err := c.client.Assets(repository, release.ID)
+				if err != nil {
+					success = 0
+					log.Errorf(
+						"failed to collect repo %s, release %s: %s",
+						repository,
+						release.Tag,
+						err.Error(),
+					)
+					continue
+				}
+				for _, asset := range assets {
+					ext := strings.TrimPrefix(filepath.Ext(asset.Name), ".")
+					log.Debugf(
+						"collecting %s@%s / %s (%s)",
+						repository,
+						release.Tag,
+						asset.Name,
+						ext,
+					)
+					ch <- prometheus.MustNewConstMetric(
+						c.downloads,
+						prometheus.CounterValue,
+						float64(asset.Downloads),
+						repository,
+						release.Tag,
+						asset.Name,
+						ext,
+					)
+				}
 			}
 		}
 	}

--- a/collector/releases.go
+++ b/collector/releases.go
@@ -49,48 +49,45 @@ func NewReleasesCollector(config *config.Config, client client.Client) prometheu
 				nil,
 			),
 		}
-	} else {
-		return &releasesCollector{
-			config: config,
-			client: client,
-			release: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, subsystem, "latest_info"),
-				"Latest release info of the repo",
-				[]string{"repository", "tag", "name"},
-				nil,
-			),
-			up: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, subsystem, "up"),
-				"Exporter is being able to talk with GitHub API",
-				nil,
-				nil,
-			),
-			downloads: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, subsystem, "asset_download_count"),
-				"Download count of each asset of a github release",
-				[]string{"repository", "tag", "name", "extension"},
-				nil,
-			),
-			scrapeDuration: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, subsystem, "scrape_duration_seconds"),
-				"Returns how long the probe took to complete in seconds",
-				nil,
-				nil,
-			),
-		}
+	}
+	return &releasesCollector{
+		config: config,
+		client: client,
+		release: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "latest_info"),
+			"Latest release info of the repo",
+			[]string{"repository", "tag", "name"},
+			nil,
+		),
+		up: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "up"),
+			"Exporter is being able to talk with GitHub API",
+			nil,
+			nil,
+		),
+		downloads: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "asset_download_count"),
+			"Download count of each asset of a github release",
+			[]string{"repository", "tag", "name", "extension"},
+			nil,
+		),
+		scrapeDuration: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "scrape_duration_seconds"),
+			"Returns how long the probe took to complete in seconds",
+			nil,
+			nil,
+		),
 	}
 }
 
 // Describe all metrics
 func (c *releasesCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.up
+	ch <- c.scrapeDuration
 	if c.config.OnlyNewReleaseInfo {
-		ch <- c.up
 		ch <- c.release
-		ch <- c.scrapeDuration
 	} else {
-		ch <- c.up
 		ch <- c.downloads
-		ch <- c.scrapeDuration
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -11,9 +11,9 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-// Config struct representing the config file.
 type Config struct {
-	Repositories []string `yaml:"repositories"`
+	OnlyNewReleaseInfo bool     `yaml:"only_new_release_info"`
+	Repositories       []string `yaml:"repositories"`
 }
 
 func doLoad(file string, config *Config) error {

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,4 @@
+only_new_release_info: true
 repositories:
 - caarlos0/github_releases_exporter
 - goreleaser/goreleaser


### PR DESCRIPTION
### This PR adds ability to monitor only latest releases of the repo
__Hi @caarlos0 thank you for creating the exporter!__  

I was trying to find release monitor for github, that's able to export metrics to prometheus and came across your repo.  

I'd like to create the alert in prometheus to get notified about new release of the repo.  Unfortunately it was not possible to create such alert with your exporter. 
  
There is no any needs to get information about assets of new release as well, if someone wants to just receive the notification about new release.  

I have modified the exporter a little bit and could succeed in achieving the goal via simple prometheus query:
```
  - alert: NewRelease
    expr: topk(1, github_release_latest_info) > on() group_left(job) topk(1, github_release_latest_info offset 5m)
    for: 4m
    labels:
      severity: info
    annotations:
      summary: New version of software released!
      description: >
        New release {{ $labels.name }} in repo {{ $labels.repository }} with tag {{$labels.tag}} has been released.
        Check it at https://github.com/{{$labels.repository}}/releases/tag/{{$labels.tag}}

```

I also removed the collection of many extra data of the release if someone needs only to get information about latest release.  

_I believe I am not the only person who needs this functionality, but I was wondering of absence such exporter, but with my PR adding `only_new_release_info: true` to config file enables this functionality._
_